### PR TITLE
Fix custom query parameter delimiting

### DIFF
--- a/DbgCensus.Rest/Queries/QueryBuilder.cs
+++ b/DbgCensus.Rest/Queries/QueryBuilder.cs
@@ -95,8 +95,8 @@ public sealed class QueryBuilder : IQueryBuilder
         }
 
         // Add any custom parameters
-        if (_customParameters.Count > 0)
-            builder.Query += string.Join('&', _customParameters);
+        foreach (string custom in _customParameters)
+            builder.Query += $"{custom}&";
 
         // Add filters
         foreach (QueryFilter filter in _filters)

--- a/DbgCensus.Rest/Queries/QueryBuilder.cs
+++ b/DbgCensus.Rest/Queries/QueryBuilder.cs
@@ -87,16 +87,16 @@ public sealed class QueryBuilder : IQueryBuilder
             return builder.Uri;
         builder.Path += $"/{CollectionName}";
 
-        // Add any custom parameters
-        if (_customParameters.Count > 0)
-            builder.Query += string.Join('&', _customParameters);
-
         // Add distinct command
         if (_distinctField.HasArgument)
         {
             builder.Query = _distinctField;
             return builder.Uri; // Querying doesn't work in tandem with the distinct command
         }
+
+        // Add any custom parameters
+        if (_customParameters.Count > 0)
+            builder.Query += string.Join('&', _customParameters);
 
         // Add filters
         foreach (QueryFilter filter in _filters)


### PR DESCRIPTION
Fixes an issue with custom query parameters not delimiting from the rest of the string and forming an invalid URI.

For example, adding `c:censusJSON=false` as a custom parameter would make this query: `?c:censusJSON=falsec:lang=en&c:limit=5000`, missing the `&` before `c:lang=en`.

- The distinct command check now happens before adding custom parameters because it ignores them anyway.
- Custom parameters are now added in the same manner as query filters, including the trailing ampersand.